### PR TITLE
Update link types for events

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,5 +1,6 @@
 import type { InputValue } from '@portabletext/svelte';
 
+
 export type EventPost = {
 	id: string;
 	name: string;
@@ -8,13 +9,15 @@ export type EventPost = {
 	time: string;
 	location: string;
 	thumbnail: string;
-	reglink: string;
 	category: string;
-	paylink: string; // event payment link (e.g., Zeffy)
+	links: [{
+		title: string,
+		kind: string, // payment, registration, general (enum `kind`)
+		url: string
+	}],
 };
 
 export type Category = 'allEvents' | 'academic' | 'professional' | 'social' | 'technical';
-
 
 export type FAQ = {
 	question: string;

--- a/src/routes/events/+page.server.ts
+++ b/src/routes/events/+page.server.ts
@@ -7,21 +7,24 @@ const eventQuery = `*[_type == "events"]{
   date,
   location,
   description,
-  reglink,
-  paylink,
+  "links": links[]{
+    "kind": kind,
+    "title": title,
+    "url": url
+    },
   "thumbnail": thumbnail.asset->url+"?h=800&fm=webp",
   "lastUpdated": _updatedAt,
 }`;
 
 export const load = async ({ url }) => {
-	let listOfEvents: EventPost[] = await getFromCMS(eventQuery);
+  let listOfEvents: EventPost[] = await getFromCMS(eventQuery);
 
-	let sortedEvents = listOfEvents.sort(
-		(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-	);
+  let sortedEvents = listOfEvents.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
 
-	return {
-		events: sortedEvents,
-		canonical: url.href
-	};
+  return {
+    events: sortedEvents,
+    canonical: url.href
+  };
 };


### PR DESCRIPTION
Previously the links are separated fields, i.e., "reglink" and "paylink"

I wanted to generalize this by having "links" as a list/array, and it contains different **kinds** of links.

Each link contain `{ title, kind, url }` where `kind` can be "payment", "registration", and "general". Payment and Registration are restricted to have 1 only, whereas General links can be unlimited amount (can be resources, photo drive, slideshow, etc.) 

These are updated on the CMS side long ago, only until now that I update it on the frontend.
