### PR TITLE
Events: popup dialog, CSS-class filtering, smaller tiles

### DIFF
--- a/src/components/event/EventBlock.svelte
+++ b/src/components/event/EventBlock.svelte
@@ -29,11 +29,16 @@
 		if (!category || category.length === 0) return '/ECSESS.png';
 		const cat = Array.isArray(category) ? category[0] : category;
 		switch (cat) {
-			case 'social': return '/Social.jpg';
-			case 'technical': return '/Technical.jpg';
-			case 'professional': return '/Professional.jpg';
-			case 'academic': return '/Academic.jpg';
-			default: return '/ECSESS.png';
+			case 'social':
+				return '/Social.jpg';
+			case 'technical':
+				return '/Technical.jpg';
+			case 'professional':
+				return '/Professional.jpg';
+			case 'academic':
+				return '/Academic.jpg';
+			default:
+				return '/ECSESS.png';
 		}
 	};
 
@@ -41,7 +46,9 @@
 
 	const categoryLabel = $derived(
 		eventCategory && eventCategory.length > 0
-			? (Array.isArray(eventCategory) ? eventCategory : [eventCategory])
+			? Array.isArray(eventCategory)
+				? eventCategory
+				: [eventCategory]
 			: []
 	);
 </script>
@@ -66,24 +73,35 @@
 		/>
 
 		<!-- Hover overlay -->
-		<div class="absolute inset-0 flex items-center justify-center bg-ecsess-950/0 transition-colors duration-200 group-hover:bg-ecsess-950/50">
-			<Eye class="h-7 w-7 text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100" strokeWidth={1.5} />
+		<div
+			class="bg-ecsess-950/0 group-hover:bg-ecsess-950/50 absolute inset-0 flex items-center justify-center transition-colors duration-200"
+		>
+			<Eye
+				class="h-7 w-7 text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+				strokeWidth={1.5}
+			/>
 		</div>
 
 		<!-- Status + category badges -->
 		<div class="absolute top-2 left-2 flex flex-wrap gap-1">
 			{#if isPastEvent}
-				<span class="rounded bg-ecsess-950/75 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-ecsess-400 backdrop-blur-sm">
+				<span
+					class="bg-ecsess-950/75 text-ecsess-400 rounded px-1.5 py-0.5 text-[9px] font-bold tracking-widest uppercase backdrop-blur-sm"
+				>
 					Past
 				</span>
 			{:else}
-				<span class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-white">
-					<span class="h-1 w-1 rounded-full bg-white animate-pulse"></span>
+				<span
+					class="bg-ecsess-500 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[9px] font-bold tracking-widest text-white uppercase"
+				>
+					<span class="h-1 w-1 animate-pulse rounded-full bg-white"></span>
 					Upcoming
 				</span>
 			{/if}
 			{#each categoryLabel as cat}
-				<span class="rounded bg-ecsess-900/80 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
+				<span
+					class="bg-ecsess-900/80 text-ecsess-300 rounded px-1.5 py-0.5 text-[9px] font-bold tracking-widest uppercase backdrop-blur-sm"
+				>
 					{cat}
 				</span>
 			{/each}
@@ -92,16 +110,16 @@
 
 	<!-- Post meta below image -->
 	<div class="pt-2">
-		<h2 class="text-[11px] font-bold leading-snug text-ecsess-50 text-balance mb-1 line-clamp-2">
+		<h2 class="text-ecsess-50 mb-1 line-clamp-2 text-[11px] leading-snug font-bold text-balance">
 			{eventTitle}
 		</h2>
-		<div class="flex flex-col gap-0.5 text-[10px] text-ecsess-400">
+		<div class="text-ecsess-400 flex flex-col gap-0.5 text-[10px]">
 			<span class="flex items-center gap-1">
-				<CalendarDays class="h-2.5 w-2.5 shrink-0 text-ecsess-500" strokeWidth={2} />
+				<CalendarDays class="text-ecsess-500 h-2.5 w-2.5 shrink-0" strokeWidth={2} />
 				{date}
 			</span>
 			<span class="flex items-center gap-1">
-				<MapPin class="h-2.5 w-2.5 shrink-0 text-ecsess-500" strokeWidth={2} />
+				<MapPin class="text-ecsess-500 h-2.5 w-2.5 shrink-0" strokeWidth={2} />
 				{location ?? 'TBA'}
 			</span>
 		</div>

--- a/src/components/event/EventBlock.svelte
+++ b/src/components/event/EventBlock.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import type { LinkType } from '$lib/schemas';
 	import type { InputValue } from '@portabletext/svelte';
-	import EventImageHeader from './EBComponents/EventImageHeader.svelte';
-	import EventBadges from './EBComponents/EventBadges.svelte';
-	import EventInfoGrid from './EBComponents/EventInfoGrid.svelte';
-	import EventActionButtons from './EBComponents/EventActionButtons.svelte';
-	import EventDescription from './EBComponents/EventDescription.svelte';
+	import { CalendarDays, MapPin, FilePen, CalendarPlus, ExternalLink, ChevronDown } from '@lucide/svelte';
+	import RichText from 'components/RichText.svelte';
 
 	let {
 		eventTitle,
@@ -31,16 +28,32 @@
 		isPastEvent?: boolean;
 	}>();
 
-	let showDescription = $state(false);
+	let expanded = $state(false);
+
+	const getDefaultImage = (category?: string[]): string => {
+		if (!category || category.length === 0) return '/ECSESS.png';
+		const cat = Array.isArray(category) ? category[0] : category;
+		switch (cat) {
+			case 'social': return '/Social.jpg';
+			case 'technical': return '/Technical.jpg';
+			case 'professional': return '/Professional.jpg';
+			case 'academic': return '/Academic.jpg';
+			default: return '/ECSESS.png';
+		}
+	};
+
+	const imageSrc = $derived(thumbnail || getDefaultImage(eventCategory));
+
+	const categoryLabel = $derived(
+		eventCategory && eventCategory.length > 0
+			? (Array.isArray(eventCategory) ? eventCategory : [eventCategory])
+			: []
+	);
 
 	const addToCalendar = () => {
 		const eventDate = new Date(date);
 		const endDate = new Date(eventDate.getTime() + 2 * 60 * 60 * 1000);
-
-		const formatDate = (d: Date) => {
-			return d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-		};
-
+		const formatDate = (d: Date) => d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
 		const icsContent = [
 			'BEGIN:VCALENDAR',
 			'VERSION:2.0',
@@ -54,7 +67,6 @@
 			'END:VEVENT',
 			'END:VCALENDAR'
 		].join('\n');
-
 		const blob = new Blob([icsContent], { type: 'text/calendar' });
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement('a');
@@ -65,67 +77,134 @@
 		document.body.removeChild(link);
 		URL.revokeObjectURL(url);
 	};
-
-	const flipCard = () => {
-		showDescription = !showDescription;
-	};
-
-	const handleKeyDown = (e: KeyboardEvent) => {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			flipCard();
-		}
-	};
 </script>
 
-<div class="group relative flex h-full w-full flex-col rounded-2xl perspective-[1000px]">
-	<div
-		class="grid h-full w-full rounded-2xl text-center transition-transform duration-500 transform-3d {showDescription
-			? 'transform-[rotateY(180deg)]'
-			: 'hover:animate-wiggle transform-[rotateY(0)]'}"
-	>
-		<!-- Front Side -->
-		<div
-			class="bg-ecsess-950 col-start-1 row-start-1 flex h-full w-full transform-[rotateY(0)] cursor-pointer flex-col rounded-2xl transition-opacity duration-500 backface-hidden {showDescription
-				? 'pointer-events-none opacity-0'
-				: 'opacity-100'}"
-			data-flip-side="front"
-			role="button"
-			tabindex="0"
-			onclick={flipCard}
-			onkeydown={handleKeyDown}
-			aria-label="Flip event card to view description"
-		>
-			<EventImageHeader {eventTitle} {thumbnail} {eventCategory} />
-			<EventBadges {isPastEvent} {eventCategory} />
+<!-- Post-style event entry -->
+<article class="border-b border-ecsess-800/60 pb-10 last:border-0" class:opacity-70={isPastEvent}>
+	<!-- Banner Image -->
+	<div class="relative mb-5 overflow-hidden rounded-xl" style="aspect-ratio: 16/7;">
+		<img
+			src={imageSrc}
+			alt={eventTitle}
+			class="h-full w-full object-cover"
+			class:grayscale={isPastEvent}
+		/>
+		<!-- Subtle bottom gradient for readability -->
+		<div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-ecsess-950/60 via-transparent to-transparent rounded-xl"></div>
+	</div>
 
-			<EventInfoGrid {date} {location} />
+	<!-- Meta row: status + categories -->
+	<div class="mb-3 flex flex-wrap items-center gap-2">
+		{#if isPastEvent}
+			<span class="inline-flex items-center gap-1.5 rounded-full border border-ecsess-700/60 bg-ecsess-900/60 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-400">
+				Past Event
+			</span>
+		{:else}
+			<span class="inline-flex items-center gap-1.5 rounded-full bg-ecsess-500 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-50">
+				<span class="h-1.5 w-1.5 rounded-full bg-ecsess-100 animate-pulse-ring"></span>
+				Upcoming
+			</span>
+		{/if}
 
-			{#if !isPastEvent}
-				<div class="pointer-events-auto relative z-30 flex-1 px-6 pt-0 pb-4">
-					<EventActionButtons {registrationLink} {paymentLink} {addToCalendar} />
-				</div>
-			{/if}
+		{#each categoryLabel as cat}
+			<span class="rounded-full border border-ecsess-700/40 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-300">
+				{cat}
+			</span>
+		{/each}
+	</div>
 
-			<div class="p-4 lg:hidden">
-				<p class="text-ecsess-400 text-sm">Click to view more</p>
+	<!-- Title -->
+	<h2 class="mb-4 text-xl font-bold leading-snug text-ecsess-50 text-balance md:text-2xl">
+		{eventTitle}
+	</h2>
+
+	<!-- Date & location inline row -->
+	<div class="mb-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-ecsess-300">
+		<span class="flex items-center gap-1.5">
+			<CalendarDays class="h-4 w-4 text-ecsess-400" strokeWidth={2} />
+			{date}
+		</span>
+		<span class="hidden text-ecsess-700 sm:inline">|</span>
+		<span class="flex items-center gap-1.5">
+			<MapPin class="h-4 w-4 text-ecsess-400" strokeWidth={2} />
+			{location ?? 'TBA'}
+		</span>
+	</div>
+
+	<!-- Action row -->
+	<div class="flex flex-wrap items-center gap-3">
+		{#if !isPastEvent && registrationLink}
+			<a
+				href={registrationLink[0].url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="inline-flex items-center gap-2 rounded-lg bg-ecsess-500 px-5 py-2.5 text-sm font-semibold text-ecsess-50 transition-colors hover:bg-ecsess-600"
+			>
+				<FilePen class="h-4 w-4" strokeWidth={2.5} />
+				Register
+			</a>
+		{/if}
+
+		{#if !isPastEvent && paymentLink}
+			<a
+				href={paymentLink[0].url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
+			>
+				<ExternalLink class="h-4 w-4" strokeWidth={2.5} />
+				Pay
+			</a>
+		{/if}
+
+		{#if !isPastEvent}
+			<button
+				type="button"
+				onclick={addToCalendar}
+				class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
+			>
+				<CalendarPlus class="h-4 w-4" strokeWidth={2.5} />
+				Add to Calendar
+			</button>
+		{/if}
+
+		{#if generalLink && generalLink.length > 0}
+			{#each generalLink.slice(0, 4) as link}
+				<a
+					href={link.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
+				>
+					<ExternalLink class="h-4 w-4" strokeWidth={2.5} />
+					{link.title}
+				</a>
+			{/each}
+		{/if}
+
+		<!-- Toggle description -->
+		{#if eventDescription}
+			<button
+				type="button"
+				onclick={() => (expanded = !expanded)}
+				class="ml-auto inline-flex items-center gap-1.5 text-sm font-semibold text-ecsess-400 transition-colors hover:text-ecsess-200"
+				aria-expanded={expanded}
+			>
+				{expanded ? 'Hide details' : 'Read more'}
+				<ChevronDown
+					class="h-4 w-4 transition-transform duration-300 {expanded ? 'rotate-180' : ''}"
+					strokeWidth={2.5}
+				/>
+			</button>
+		{/if}
+	</div>
+
+	<!-- Expandable description -->
+	{#if expanded && eventDescription}
+		<div class="mt-5 border-t border-ecsess-800/50 pt-5">
+			<div class="typography text-ecsess-100 max-w-3xl">
+				<RichText value={eventDescription} />
 			</div>
 		</div>
-
-		<!-- Back Side -->
-		<div
-			class="bg-ecsess-950 col-start-1 row-start-1 flex h-full w-full transform-[rotateY(180deg)] cursor-pointer flex-col rounded-2xl transition-opacity duration-500 backface-hidden transform-3d {showDescription
-				? 'opacity-100'
-				: 'pointer-events-none opacity-0'}"
-			data-flip-side="back"
-			class:flipped={showDescription}
-			role="button"
-			tabindex="0"
-			onclick={flipCard}
-			onkeydown={handleKeyDown}
-			aria-label="Flip event card back to front"
-		>
-			<EventDescription {eventTitle} {eventDescription} {generalLink} />
-		</div>
-	</div>
-</div>
+	{/if}
+</article>

--- a/src/components/event/EventBlock.svelte
+++ b/src/components/event/EventBlock.svelte
@@ -69,142 +69,143 @@
 		].join('\n');
 		const blob = new Blob([icsContent], { type: 'text/calendar' });
 		const url = URL.createObjectURL(blob);
-		const link = document.createElement('a');
-		link.href = url;
-		link.download = `${eventTitle.replace(/\s+/g, '_')}.ics`;
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `${eventTitle.replace(/\s+/g, '_')}.ics`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
 		URL.revokeObjectURL(url);
 	};
 </script>
 
-<!-- Post-style event entry -->
-<article class="border-b border-ecsess-800/60 pb-10 last:border-0" class:opacity-70={isPastEvent}>
-	<!-- Banner Image -->
-	<div class="relative mb-5 overflow-hidden rounded-xl" style="aspect-ratio: 16/7;">
+<!-- Instagram-style post -->
+<article class="flex flex-col" class:opacity-60={isPastEvent}>
+
+	<!-- Poster image — 4:5 portrait, object-cover; non-standard sizes fill gracefully -->
+	<div class="relative w-full overflow-hidden rounded-lg" style="aspect-ratio: 4/5;">
 		<img
 			src={imageSrc}
 			alt={eventTitle}
-			class="h-full w-full object-cover"
+			class="absolute inset-0 h-full w-full object-cover"
 			class:grayscale={isPastEvent}
 		/>
-		<!-- Subtle bottom gradient for readability -->
-		<div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-ecsess-950/60 via-transparent to-transparent rounded-xl"></div>
+		<!-- Status badge — top-left overlay -->
+		<div class="absolute top-2.5 left-2.5 flex flex-wrap gap-1.5">
+			{#if isPastEvent}
+				<span class="rounded-sm bg-ecsess-950/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
+					Past
+				</span>
+			{:else}
+				<span class="inline-flex items-center gap-1 rounded-sm bg-ecsess-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-white backdrop-blur-sm">
+					<span class="h-1.5 w-1.5 rounded-full bg-ecsess-100 animate-pulse-ring"></span>
+					Upcoming
+				</span>
+			{/if}
+
+			{#each categoryLabel as cat}
+				<span class="rounded-sm bg-ecsess-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-200 backdrop-blur-sm">
+					{cat}
+				</span>
+			{/each}
+		</div>
 	</div>
 
-	<!-- Meta row: status + categories -->
-	<div class="mb-3 flex flex-wrap items-center gap-2">
-		{#if isPastEvent}
-			<span class="inline-flex items-center gap-1.5 rounded-full border border-ecsess-700/60 bg-ecsess-900/60 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-400">
-				Past Event
+	<!-- Post body -->
+	<div class="flex flex-1 flex-col gap-2 pt-3">
+
+		<!-- Title -->
+		<h2 class="text-sm font-bold leading-snug text-ecsess-50 text-balance">
+			{eventTitle}
+		</h2>
+
+		<!-- Date & location -->
+		<div class="flex flex-col gap-0.5 text-xs text-ecsess-300">
+			<span class="flex items-center gap-1">
+				<CalendarDays class="h-3 w-3 shrink-0 text-ecsess-400" strokeWidth={2} />
+				{date}
 			</span>
-		{:else}
-			<span class="inline-flex items-center gap-1.5 rounded-full bg-ecsess-500 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-50">
-				<span class="h-1.5 w-1.5 rounded-full bg-ecsess-100 animate-pulse-ring"></span>
-				Upcoming
+			<span class="flex items-center gap-1">
+				<MapPin class="h-3 w-3 shrink-0 text-ecsess-400" strokeWidth={2} />
+				{location ?? 'TBA'}
 			</span>
-		{/if}
+		</div>
 
-		{#each categoryLabel as cat}
-			<span class="rounded-full border border-ecsess-700/40 px-3 py-0.5 text-xs font-semibold uppercase tracking-widest text-ecsess-300">
-				{cat}
-			</span>
-		{/each}
-	</div>
-
-	<!-- Title -->
-	<h2 class="mb-4 text-xl font-bold leading-snug text-ecsess-50 text-balance md:text-2xl">
-		{eventTitle}
-	</h2>
-
-	<!-- Date & location inline row -->
-	<div class="mb-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-ecsess-300">
-		<span class="flex items-center gap-1.5">
-			<CalendarDays class="h-4 w-4 text-ecsess-400" strokeWidth={2} />
-			{date}
-		</span>
-		<span class="hidden text-ecsess-700 sm:inline">|</span>
-		<span class="flex items-center gap-1.5">
-			<MapPin class="h-4 w-4 text-ecsess-400" strokeWidth={2} />
-			{location ?? 'TBA'}
-		</span>
-	</div>
-
-	<!-- Action row -->
-	<div class="flex flex-wrap items-center gap-3">
-		{#if !isPastEvent && registrationLink}
-			<a
-				href={registrationLink[0].url}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="inline-flex items-center gap-2 rounded-lg bg-ecsess-500 px-5 py-2.5 text-sm font-semibold text-ecsess-50 transition-colors hover:bg-ecsess-600"
-			>
-				<FilePen class="h-4 w-4" strokeWidth={2.5} />
-				Register
-			</a>
-		{/if}
-
-		{#if !isPastEvent && paymentLink}
-			<a
-				href={paymentLink[0].url}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
-			>
-				<ExternalLink class="h-4 w-4" strokeWidth={2.5} />
-				Pay
-			</a>
-		{/if}
-
-		{#if !isPastEvent}
-			<button
-				type="button"
-				onclick={addToCalendar}
-				class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
-			>
-				<CalendarPlus class="h-4 w-4" strokeWidth={2.5} />
-				Add to Calendar
-			</button>
-		{/if}
-
-		{#if generalLink && generalLink.length > 0}
-			{#each generalLink.slice(0, 4) as link}
+		<!-- Action buttons -->
+		<div class="flex flex-wrap items-center gap-1.5 pt-1">
+			{#if !isPastEvent && registrationLink}
 				<a
-					href={link.url}
+					href={registrationLink[0].url}
 					target="_blank"
 					rel="noopener noreferrer"
-					class="inline-flex items-center gap-2 rounded-lg border border-ecsess-700 px-5 py-2.5 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-500 hover:text-ecsess-50"
+					class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-2.5 py-1 text-xs font-semibold text-white transition-colors hover:bg-ecsess-400"
 				>
-					<ExternalLink class="h-4 w-4" strokeWidth={2.5} />
-					{link.title}
+					<FilePen class="h-3 w-3" strokeWidth={2.5} />
+					Register
 				</a>
-			{/each}
-		{/if}
+			{/if}
 
-		<!-- Toggle description -->
-		{#if eventDescription}
-			<button
-				type="button"
-				onclick={() => (expanded = !expanded)}
-				class="ml-auto inline-flex items-center gap-1.5 text-sm font-semibold text-ecsess-400 transition-colors hover:text-ecsess-200"
-				aria-expanded={expanded}
-			>
-				{expanded ? 'Hide details' : 'Read more'}
-				<ChevronDown
-					class="h-4 w-4 transition-transform duration-300 {expanded ? 'rotate-180' : ''}"
-					strokeWidth={2.5}
-				/>
-			</button>
+			{#if !isPastEvent && paymentLink}
+				<a
+					href={paymentLink[0].url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+				>
+					<ExternalLink class="h-3 w-3" strokeWidth={2.5} />
+					Pay
+				</a>
+			{/if}
+
+			{#if !isPastEvent}
+				<button
+					type="button"
+					onclick={addToCalendar}
+					class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+				>
+					<CalendarPlus class="h-3 w-3" strokeWidth={2.5} />
+					Calendar
+				</button>
+			{/if}
+
+			{#if generalLink && generalLink.length > 0}
+				{#each generalLink.slice(0, 2) as link}
+					<a
+						href={link.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+					>
+						<ExternalLink class="h-3 w-3" strokeWidth={2.5} />
+						{link.title}
+					</a>
+				{/each}
+			{/if}
+
+			<!-- Toggle description -->
+			{#if eventDescription}
+				<button
+					type="button"
+					onclick={() => (expanded = !expanded)}
+					class="ml-auto inline-flex items-center gap-0.5 text-xs font-semibold text-ecsess-400 transition-colors hover:text-ecsess-200"
+					aria-expanded={expanded}
+				>
+					{expanded ? 'Less' : 'More'}
+					<ChevronDown
+						class="h-3.5 w-3.5 transition-transform duration-200 {expanded ? 'rotate-180' : ''}"
+						strokeWidth={2.5}
+					/>
+				</button>
+			{/if}
+		</div>
+
+		<!-- Expandable description -->
+		{#if expanded && eventDescription}
+			<div class="mt-2 border-t border-ecsess-800 pt-3">
+				<div class="typography text-ecsess-100 text-xs">
+					<RichText value={eventDescription} />
+				</div>
+			</div>
 		{/if}
 	</div>
-
-	<!-- Expandable description -->
-	{#if expanded && eventDescription}
-		<div class="mt-5 border-t border-ecsess-800/50 pt-5">
-			<div class="typography text-ecsess-100 max-w-3xl">
-				<RichText value={eventDescription} />
-			</div>
-		</div>
-	{/if}
 </article>

--- a/src/components/event/EventBlock.svelte
+++ b/src/components/event/EventBlock.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
 	import type { LinkType } from '$lib/schemas';
 	import type { InputValue } from '@portabletext/svelte';
-	import { CalendarDays, MapPin, FilePen, CalendarPlus, ExternalLink, ChevronDown } from '@lucide/svelte';
-	import RichText from 'components/RichText.svelte';
+	import { CalendarDays, MapPin, Eye } from '@lucide/svelte';
 
 	let {
 		eventTitle,
 		date,
 		location,
-		eventDescription,
 		thumbnail,
-		registrationLink,
-		paymentLink,
-		generalLink,
 		eventCategory,
-		isPastEvent = false
+		isPastEvent = false,
+		onopen
 	} = $props<{
 		eventTitle: string;
 		date: string;
@@ -26,9 +22,8 @@
 		generalLink?: LinkType[] | null;
 		eventCategory?: string[];
 		isPastEvent?: boolean;
+		onopen?: () => void;
 	}>();
-
-	let expanded = $state(false);
 
 	const getDefaultImage = (category?: string[]): string => {
 		if (!category || category.length === 0) return '/ECSESS.png';
@@ -49,163 +44,66 @@
 			? (Array.isArray(eventCategory) ? eventCategory : [eventCategory])
 			: []
 	);
-
-	const addToCalendar = () => {
-		const eventDate = new Date(date);
-		const endDate = new Date(eventDate.getTime() + 2 * 60 * 60 * 1000);
-		const formatDate = (d: Date) => d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-		const icsContent = [
-			'BEGIN:VCALENDAR',
-			'VERSION:2.0',
-			'PRODID:-//ECSESS//Events//EN',
-			'BEGIN:VEVENT',
-			`DTSTART:${formatDate(eventDate)}`,
-			`DTEND:${formatDate(endDate)}`,
-			`SUMMARY:${eventTitle}`,
-			`LOCATION:${location || 'TBA'}`,
-			`DESCRIPTION:${eventTitle} - ECSESS Event`,
-			'END:VEVENT',
-			'END:VCALENDAR'
-		].join('\n');
-		const blob = new Blob([icsContent], { type: 'text/calendar' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `${eventTitle.replace(/\s+/g, '_')}.ics`;
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
-	};
 </script>
 
-<!-- Instagram-style post -->
-<article class="flex flex-col" class:opacity-60={isPastEvent}>
-
-	<!-- Poster image — 4:5 portrait, object-cover; non-standard sizes fill gracefully -->
-	<div class="relative w-full overflow-hidden rounded-lg" style="aspect-ratio: 4/5;">
+<!-- Post tile -->
+<article
+	class="group flex cursor-pointer flex-col"
+	class:opacity-55={isPastEvent}
+	onclick={onopen}
+	role="button"
+	tabindex="0"
+	onkeydown={(e) => e.key === 'Enter' && onopen?.()}
+	aria-label="View {eventTitle} details"
+>
+	<!-- Poster image — 4:5 portrait -->
+	<div class="relative w-full overflow-hidden rounded-md" style="aspect-ratio: 4/5;">
 		<img
 			src={imageSrc}
 			alt={eventTitle}
-			class="absolute inset-0 h-full w-full object-cover"
+			class="absolute inset-0 h-full w-full object-cover transition-[filter] duration-300"
 			class:grayscale={isPastEvent}
 		/>
-		<!-- Status badge — top-left overlay -->
-		<div class="absolute top-2.5 left-2.5 flex flex-wrap gap-1.5">
+
+		<!-- Hover overlay -->
+		<div class="absolute inset-0 flex items-center justify-center bg-ecsess-950/0 transition-colors duration-200 group-hover:bg-ecsess-950/50">
+			<Eye class="h-7 w-7 text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100" strokeWidth={1.5} />
+		</div>
+
+		<!-- Status + category badges -->
+		<div class="absolute top-2 left-2 flex flex-wrap gap-1">
 			{#if isPastEvent}
-				<span class="rounded-sm bg-ecsess-950/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
+				<span class="rounded bg-ecsess-950/75 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-ecsess-400 backdrop-blur-sm">
 					Past
 				</span>
 			{:else}
-				<span class="inline-flex items-center gap-1 rounded-sm bg-ecsess-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-white backdrop-blur-sm">
-					<span class="h-1.5 w-1.5 rounded-full bg-ecsess-100 animate-pulse-ring"></span>
+				<span class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-white">
+					<span class="h-1 w-1 rounded-full bg-white animate-pulse"></span>
 					Upcoming
 				</span>
 			{/if}
-
 			{#each categoryLabel as cat}
-				<span class="rounded-sm bg-ecsess-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-200 backdrop-blur-sm">
+				<span class="rounded bg-ecsess-900/80 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
 					{cat}
 				</span>
 			{/each}
 		</div>
 	</div>
 
-	<!-- Post body -->
-	<div class="flex flex-1 flex-col gap-2 pt-3">
-
-		<!-- Title -->
-		<h2 class="text-sm font-bold leading-snug text-ecsess-50 text-balance">
+	<!-- Post meta below image -->
+	<div class="pt-2">
+		<h2 class="text-[11px] font-bold leading-snug text-ecsess-50 text-balance mb-1 line-clamp-2">
 			{eventTitle}
 		</h2>
-
-		<!-- Date & location -->
-		<div class="flex flex-col gap-0.5 text-xs text-ecsess-300">
+		<div class="flex flex-col gap-0.5 text-[10px] text-ecsess-400">
 			<span class="flex items-center gap-1">
-				<CalendarDays class="h-3 w-3 shrink-0 text-ecsess-400" strokeWidth={2} />
+				<CalendarDays class="h-2.5 w-2.5 shrink-0 text-ecsess-500" strokeWidth={2} />
 				{date}
 			</span>
 			<span class="flex items-center gap-1">
-				<MapPin class="h-3 w-3 shrink-0 text-ecsess-400" strokeWidth={2} />
+				<MapPin class="h-2.5 w-2.5 shrink-0 text-ecsess-500" strokeWidth={2} />
 				{location ?? 'TBA'}
 			</span>
 		</div>
-
-		<!-- Action buttons -->
-		<div class="flex flex-wrap items-center gap-1.5 pt-1">
-			{#if !isPastEvent && registrationLink}
-				<a
-					href={registrationLink[0].url}
-					target="_blank"
-					rel="noopener noreferrer"
-					class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-2.5 py-1 text-xs font-semibold text-white transition-colors hover:bg-ecsess-400"
-				>
-					<FilePen class="h-3 w-3" strokeWidth={2.5} />
-					Register
-				</a>
-			{/if}
-
-			{#if !isPastEvent && paymentLink}
-				<a
-					href={paymentLink[0].url}
-					target="_blank"
-					rel="noopener noreferrer"
-					class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
-				>
-					<ExternalLink class="h-3 w-3" strokeWidth={2.5} />
-					Pay
-				</a>
-			{/if}
-
-			{#if !isPastEvent}
-				<button
-					type="button"
-					onclick={addToCalendar}
-					class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
-				>
-					<CalendarPlus class="h-3 w-3" strokeWidth={2.5} />
-					Calendar
-				</button>
-			{/if}
-
-			{#if generalLink && generalLink.length > 0}
-				{#each generalLink.slice(0, 2) as link}
-					<a
-						href={link.url}
-						target="_blank"
-						rel="noopener noreferrer"
-						class="inline-flex items-center gap-1 rounded border border-ecsess-600 px-2.5 py-1 text-xs font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
-					>
-						<ExternalLink class="h-3 w-3" strokeWidth={2.5} />
-						{link.title}
-					</a>
-				{/each}
-			{/if}
-
-			<!-- Toggle description -->
-			{#if eventDescription}
-				<button
-					type="button"
-					onclick={() => (expanded = !expanded)}
-					class="ml-auto inline-flex items-center gap-0.5 text-xs font-semibold text-ecsess-400 transition-colors hover:text-ecsess-200"
-					aria-expanded={expanded}
-				>
-					{expanded ? 'Less' : 'More'}
-					<ChevronDown
-						class="h-3.5 w-3.5 transition-transform duration-200 {expanded ? 'rotate-180' : ''}"
-						strokeWidth={2.5}
-					/>
-				</button>
-			{/if}
-		</div>
-
-		<!-- Expandable description -->
-		{#if expanded && eventDescription}
-			<div class="mt-2 border-t border-ecsess-800 pt-3">
-				<div class="typography text-ecsess-100 text-xs">
-					<RichText value={eventDescription} />
-				</div>
-			</div>
-		{/if}
 	</div>
 </article>

--- a/src/components/event/EventDialog.svelte
+++ b/src/components/event/EventDialog.svelte
@@ -36,18 +36,25 @@
 		if (!category || category.length === 0) return '/ECSESS.png';
 		const cat = Array.isArray(category) ? category[0] : category;
 		switch (cat) {
-			case 'social': return '/Social.jpg';
-			case 'technical': return '/Technical.jpg';
-			case 'professional': return '/Professional.jpg';
-			case 'academic': return '/Academic.jpg';
-			default: return '/ECSESS.png';
+			case 'social':
+				return '/Social.jpg';
+			case 'technical':
+				return '/Technical.jpg';
+			case 'professional':
+				return '/Professional.jpg';
+			case 'academic':
+				return '/Academic.jpg';
+			default:
+				return '/ECSESS.png';
 		}
 	};
 
 	const imageSrc = $derived(thumbnail || getDefaultImage(eventCategory));
 	const categoryLabel = $derived(
 		eventCategory && eventCategory.length > 0
-			? (Array.isArray(eventCategory) ? eventCategory : [eventCategory])
+			? Array.isArray(eventCategory)
+				? eventCategory
+				: [eventCategory]
 			: []
 	);
 
@@ -98,19 +105,21 @@
 	aria-modal="true"
 	aria-label={eventTitle}
 	class="fixed inset-0 z-50 flex items-center justify-center p-4 transition-all duration-200
-		{open ? 'pointer-events-auto bg-ecsess-950/80 backdrop-blur-sm' : 'pointer-events-none bg-transparent backdrop-blur-none opacity-0'}"
+		{open
+		? 'bg-ecsess-950/80 pointer-events-auto backdrop-blur-sm'
+		: 'pointer-events-none bg-transparent opacity-0 backdrop-blur-none'}"
 >
 	<div
-		class="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-ecsess-800 bg-ecsess-950
+		class="border-ecsess-800 bg-ecsess-950 relative flex w-full max-w-2xl flex-col overflow-hidden rounded-xl border
 			shadow-2xl transition-all duration-200
-			{open ? 'translate-y-0 opacity-100 scale-100' : 'translate-y-4 opacity-0 scale-95'}"
+			{open ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-4 scale-95 opacity-0'}"
 		style="max-height: 90dvh;"
 	>
 		<!-- Close button -->
 		<button
 			type="button"
 			onclick={onclose}
-			class="absolute right-3 top-3 z-10 rounded-full bg-ecsess-950/70 p-1.5 text-ecsess-400 backdrop-blur-sm transition-colors hover:bg-ecsess-800 hover:text-ecsess-50"
+			class="bg-ecsess-950/70 text-ecsess-400 hover:bg-ecsess-800 hover:text-ecsess-50 absolute top-3 right-3 z-10 rounded-full p-1.5 backdrop-blur-sm transition-colors"
 			aria-label="Close dialog"
 		>
 			<X class="h-4 w-4" strokeWidth={2} />
@@ -129,17 +138,23 @@
 				<!-- Badges over image -->
 				<div class="absolute bottom-3 left-3 flex flex-wrap gap-1.5">
 					{#if isPastEvent}
-						<span class="rounded bg-ecsess-950/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
+						<span
+							class="bg-ecsess-950/80 text-ecsess-300 rounded px-2 py-0.5 text-[10px] font-bold tracking-widest uppercase backdrop-blur-sm"
+						>
 							Past
 						</span>
 					{:else}
-						<span class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-white">
-							<span class="h-1.5 w-1.5 rounded-full bg-white animate-pulse"></span>
+						<span
+							class="bg-ecsess-500 inline-flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-bold tracking-widest text-white uppercase"
+						>
+							<span class="h-1.5 w-1.5 animate-pulse rounded-full bg-white"></span>
 							Upcoming
 						</span>
 					{/if}
 					{#each categoryLabel as cat}
-						<span class="rounded bg-ecsess-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-200 backdrop-blur-sm">
+						<span
+							class="bg-ecsess-900/80 text-ecsess-200 rounded px-2 py-0.5 text-[10px] font-bold tracking-widest uppercase backdrop-blur-sm"
+						>
 							{cat}
 						</span>
 					{/each}
@@ -149,26 +164,26 @@
 			<!-- Dialog body -->
 			<div class="flex flex-col gap-4 p-5">
 				<!-- Title -->
-				<h2 class="text-xl font-bold leading-snug text-ecsess-50 text-balance">
+				<h2 class="text-ecsess-50 text-xl leading-snug font-bold text-balance">
 					{eventTitle}
 				</h2>
 
 				<!-- Meta -->
-				<div class="flex flex-col gap-1.5 text-sm text-ecsess-300">
+				<div class="text-ecsess-300 flex flex-col gap-1.5 text-sm">
 					<span class="flex items-center gap-2">
-						<CalendarDays class="h-4 w-4 shrink-0 text-ecsess-500" strokeWidth={2} />
+						<CalendarDays class="text-ecsess-500 h-4 w-4 shrink-0" strokeWidth={2} />
 						{date}
 					</span>
 					<span class="flex items-center gap-2">
-						<MapPin class="h-4 w-4 shrink-0 text-ecsess-500" strokeWidth={2} />
+						<MapPin class="text-ecsess-500 h-4 w-4 shrink-0" strokeWidth={2} />
 						{location ?? 'TBA'}
 					</span>
 				</div>
 
 				<!-- Description -->
 				{#if eventDescription}
-					<div class="border-t border-ecsess-800 pt-4">
-						<div class="typography text-sm text-ecsess-200">
+					<div class="border-ecsess-800 border-t pt-4">
+						<div class="typography text-ecsess-200 text-sm">
 							<RichText value={eventDescription} />
 						</div>
 					</div>
@@ -176,13 +191,13 @@
 
 				<!-- Action buttons -->
 				{#if !isPastEvent || generalLink}
-					<div class="flex flex-wrap gap-2 border-t border-ecsess-800 pt-4">
+					<div class="border-ecsess-800 flex flex-wrap gap-2 border-t pt-4">
 						{#if !isPastEvent && registrationLink}
 							<a
 								href={registrationLink[0].url}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="inline-flex items-center gap-1.5 rounded-md bg-ecsess-500 px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-ecsess-400"
+								class="bg-ecsess-500 hover:bg-ecsess-400 inline-flex items-center gap-1.5 rounded-md px-3.5 py-2 text-sm font-semibold text-white transition-colors"
 							>
 								<FilePen class="h-3.5 w-3.5" strokeWidth={2.5} />
 								Register
@@ -194,7 +209,7 @@
 								href={paymentLink[0].url}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+								class="border-ecsess-600 text-ecsess-200 hover:border-ecsess-400 hover:text-ecsess-50 inline-flex items-center gap-1.5 rounded-md border px-3.5 py-2 text-sm font-semibold transition-colors"
 							>
 								<ExternalLink class="h-3.5 w-3.5" strokeWidth={2.5} />
 								Pay
@@ -205,7 +220,7 @@
 							<button
 								type="button"
 								onclick={addToCalendar}
-								class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+								class="border-ecsess-600 text-ecsess-200 hover:border-ecsess-400 hover:text-ecsess-50 inline-flex items-center gap-1.5 rounded-md border px-3.5 py-2 text-sm font-semibold transition-colors"
 							>
 								<CalendarPlus class="h-3.5 w-3.5" strokeWidth={2.5} />
 								Add to Calendar
@@ -218,7 +233,7 @@
 									href={link.url}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+									class="border-ecsess-600 text-ecsess-200 hover:border-ecsess-400 hover:text-ecsess-50 inline-flex items-center gap-1.5 rounded-md border px-3.5 py-2 text-sm font-semibold transition-colors"
 								>
 									<ExternalLink class="h-3.5 w-3.5" strokeWidth={2.5} />
 									{link.title}

--- a/src/components/event/EventDialog.svelte
+++ b/src/components/event/EventDialog.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	import type { LinkType } from '$lib/schemas';
+	import type { InputValue } from '@portabletext/svelte';
+	import { CalendarDays, MapPin, FilePen, CalendarPlus, ExternalLink, X } from '@lucide/svelte';
+	import RichText from 'components/RichText.svelte';
+
+	let {
+		open = false,
+		eventTitle = '',
+		date = '',
+		location,
+		eventDescription,
+		thumbnail,
+		registrationLink,
+		paymentLink,
+		generalLink,
+		eventCategory,
+		isPastEvent = false,
+		onclose
+	} = $props<{
+		open: boolean;
+		eventTitle: string;
+		date: string;
+		location?: string;
+		eventDescription?: InputValue;
+		thumbnail?: string;
+		registrationLink?: LinkType[] | null;
+		paymentLink?: LinkType[] | null;
+		generalLink?: LinkType[] | null;
+		eventCategory?: string[];
+		isPastEvent?: boolean;
+		onclose: () => void;
+	}>();
+
+	const getDefaultImage = (category?: string[]): string => {
+		if (!category || category.length === 0) return '/ECSESS.png';
+		const cat = Array.isArray(category) ? category[0] : category;
+		switch (cat) {
+			case 'social': return '/Social.jpg';
+			case 'technical': return '/Technical.jpg';
+			case 'professional': return '/Professional.jpg';
+			case 'academic': return '/Academic.jpg';
+			default: return '/ECSESS.png';
+		}
+	};
+
+	const imageSrc = $derived(thumbnail || getDefaultImage(eventCategory));
+	const categoryLabel = $derived(
+		eventCategory && eventCategory.length > 0
+			? (Array.isArray(eventCategory) ? eventCategory : [eventCategory])
+			: []
+	);
+
+	const addToCalendar = () => {
+		const eventDate = new Date(date);
+		const endDate = new Date(eventDate.getTime() + 2 * 60 * 60 * 1000);
+		const formatDate = (d: Date) => d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+		const icsContent = [
+			'BEGIN:VCALENDAR',
+			'VERSION:2.0',
+			'PRODID:-//ECSESS//Events//EN',
+			'BEGIN:VEVENT',
+			`DTSTART:${formatDate(eventDate)}`,
+			`DTEND:${formatDate(endDate)}`,
+			`SUMMARY:${eventTitle}`,
+			`LOCATION:${location || 'TBA'}`,
+			`DESCRIPTION:${eventTitle} - ECSESS Event`,
+			'END:VEVENT',
+			'END:VCALENDAR'
+		].join('\n');
+		const blob = new Blob([icsContent], { type: 'text/calendar' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `${eventTitle.replace(/\s+/g, '_')}.ics`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	};
+
+	const handleBackdropClick = (e: MouseEvent) => {
+		if ((e.target as HTMLElement).dataset.backdrop) onclose();
+	};
+
+	const handleKeydown = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') onclose();
+	};
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- Backdrop + dialog -->
+<div
+	data-backdrop="true"
+	onclick={handleBackdropClick}
+	role="dialog"
+	aria-modal="true"
+	aria-label={eventTitle}
+	class="fixed inset-0 z-50 flex items-center justify-center p-4 transition-all duration-200
+		{open ? 'pointer-events-auto bg-ecsess-950/80 backdrop-blur-sm' : 'pointer-events-none bg-transparent backdrop-blur-none opacity-0'}"
+>
+	<div
+		class="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-ecsess-800 bg-ecsess-950
+			shadow-2xl transition-all duration-200
+			{open ? 'translate-y-0 opacity-100 scale-100' : 'translate-y-4 opacity-0 scale-95'}"
+		style="max-height: 90dvh;"
+	>
+		<!-- Close button -->
+		<button
+			type="button"
+			onclick={onclose}
+			class="absolute right-3 top-3 z-10 rounded-full bg-ecsess-950/70 p-1.5 text-ecsess-400 backdrop-blur-sm transition-colors hover:bg-ecsess-800 hover:text-ecsess-50"
+			aria-label="Close dialog"
+		>
+			<X class="h-4 w-4" strokeWidth={2} />
+		</button>
+
+		<!-- Scrollable content -->
+		<div class="overflow-y-auto">
+			<!-- Header image — 16:7 landscape for dialog -->
+			<div class="relative w-full" style="aspect-ratio: 16/7;">
+				<img
+					src={imageSrc}
+					alt={eventTitle}
+					class="absolute inset-0 h-full w-full object-cover"
+					class:grayscale={isPastEvent}
+				/>
+				<!-- Badges over image -->
+				<div class="absolute bottom-3 left-3 flex flex-wrap gap-1.5">
+					{#if isPastEvent}
+						<span class="rounded bg-ecsess-950/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-300 backdrop-blur-sm">
+							Past
+						</span>
+					{:else}
+						<span class="inline-flex items-center gap-1 rounded bg-ecsess-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-white">
+							<span class="h-1.5 w-1.5 rounded-full bg-white animate-pulse"></span>
+							Upcoming
+						</span>
+					{/if}
+					{#each categoryLabel as cat}
+						<span class="rounded bg-ecsess-900/80 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-ecsess-200 backdrop-blur-sm">
+							{cat}
+						</span>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Dialog body -->
+			<div class="flex flex-col gap-4 p-5">
+				<!-- Title -->
+				<h2 class="text-xl font-bold leading-snug text-ecsess-50 text-balance">
+					{eventTitle}
+				</h2>
+
+				<!-- Meta -->
+				<div class="flex flex-col gap-1.5 text-sm text-ecsess-300">
+					<span class="flex items-center gap-2">
+						<CalendarDays class="h-4 w-4 shrink-0 text-ecsess-500" strokeWidth={2} />
+						{date}
+					</span>
+					<span class="flex items-center gap-2">
+						<MapPin class="h-4 w-4 shrink-0 text-ecsess-500" strokeWidth={2} />
+						{location ?? 'TBA'}
+					</span>
+				</div>
+
+				<!-- Description -->
+				{#if eventDescription}
+					<div class="border-t border-ecsess-800 pt-4">
+						<div class="typography text-sm text-ecsess-200">
+							<RichText value={eventDescription} />
+						</div>
+					</div>
+				{/if}
+
+				<!-- Action buttons -->
+				{#if !isPastEvent || generalLink}
+					<div class="flex flex-wrap gap-2 border-t border-ecsess-800 pt-4">
+						{#if !isPastEvent && registrationLink}
+							<a
+								href={registrationLink[0].url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="inline-flex items-center gap-1.5 rounded-md bg-ecsess-500 px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-ecsess-400"
+							>
+								<FilePen class="h-3.5 w-3.5" strokeWidth={2.5} />
+								Register
+							</a>
+						{/if}
+
+						{#if !isPastEvent && paymentLink}
+							<a
+								href={paymentLink[0].url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+							>
+								<ExternalLink class="h-3.5 w-3.5" strokeWidth={2.5} />
+								Pay
+							</a>
+						{/if}
+
+						{#if !isPastEvent}
+							<button
+								type="button"
+								onclick={addToCalendar}
+								class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+							>
+								<CalendarPlus class="h-3.5 w-3.5" strokeWidth={2.5} />
+								Add to Calendar
+							</button>
+						{/if}
+
+						{#if generalLink}
+							{#each generalLink.slice(0, 4) as link}
+								<a
+									href={link.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="inline-flex items-center gap-1.5 rounded-md border border-ecsess-600 px-3.5 py-2 text-sm font-semibold text-ecsess-200 transition-colors hover:border-ecsess-400 hover:text-ecsess-50"
+								>
+									<ExternalLink class="h-3.5 w-3.5" strokeWidth={2.5} />
+									{link.title}
+								</a>
+							{/each}
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/components/event/EventTabsContent.svelte
+++ b/src/components/event/EventTabsContent.svelte
@@ -32,12 +32,21 @@
 		const isMidnight = date.getUTCHours() === 0 && date.getUTCMinutes() === 0;
 		if (isMidnight) {
 			return date.toLocaleDateString('en-US', {
-				weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
+				weekday: 'short',
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+				timeZone: 'UTC'
 			});
 		}
 		return date.toLocaleDateString('en-US', {
-			weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
-			hour: 'numeric', minute: '2-digit', hour12: true
+			weekday: 'short',
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+			hour12: true
 		});
 	};
 
@@ -49,7 +58,11 @@
 	const getLink = (e: EventPost, type: EventLinkKind): LinkType[] | null => {
 		let generalLinks: LinkType[] = [];
 		for (const link of e.links ?? []) {
-			if (type === EventLinkKind.GENERAL && link.kind === EventLinkKind.GENERAL && link.url !== '') {
+			if (
+				type === EventLinkKind.GENERAL &&
+				link.kind === EventLinkKind.GENERAL &&
+				link.url !== ''
+			) {
 				generalLinks.push(link);
 				if (generalLinks.length >= 4) break;
 			} else if (link.kind === type && link.url !== '') {
@@ -87,26 +100,19 @@
 </script>
 
 <div class="w-full max-w-7xl py-8">
-
 	<!-- Upcoming Events -->
 	{#if upcomingEvents.length > 0}
-		<section
-			class="mb-10 transition-all duration-300"
-			class:hidden={!hasVisibleUpcoming}
-		>
+		<section class="mb-10 transition-all duration-300" class:hidden={!hasVisibleUpcoming}>
 			<div class="mb-5 flex items-center gap-3">
-				<span class="h-px flex-1 bg-ecsess-800"></span>
-				<h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
-				<span class="h-px flex-1 bg-ecsess-800"></span>
+				<span class="bg-ecsess-800 h-px flex-1"></span>
+				<h2 class="text-ecsess-400 text-[10px] font-bold tracking-[0.2em] uppercase">Upcoming</h2>
+				<span class="bg-ecsess-800 h-px flex-1"></span>
 			</div>
 
 			<!-- Grid: all upcoming events rendered; hidden class toggled by CSS only -->
 			<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
 				{#each upcomingEvents as e (e._id ?? e.name)}
-					<div
-						class="transition-opacity duration-150"
-						class:hidden={!isVisible(e)}
-					>
+					<div class="transition-opacity duration-150" class:hidden={!isVisible(e)}>
 						<EventBlock
 							eventTitle={e.name}
 							date={formatEventDate(e.date)}
@@ -124,22 +130,18 @@
 
 	<!-- Past Events -->
 	{#if pastEvents.length > 0}
-		<section
-			class="transition-all duration-300"
-			class:hidden={!hasVisiblePast}
-		>
+		<section class="transition-all duration-300" class:hidden={!hasVisiblePast}>
 			<div class="mb-5 flex items-center gap-3">
-				<span class="h-px flex-1 bg-ecsess-800"></span>
-				<h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
-				<span class="h-px flex-1 bg-ecsess-800"></span>
+				<span class="bg-ecsess-800 h-px flex-1"></span>
+				<h2 class="text-ecsess-600 text-[10px] font-bold tracking-[0.2em] uppercase">
+					Past Events
+				</h2>
+				<span class="bg-ecsess-800 h-px flex-1"></span>
 			</div>
 
 			<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
 				{#each pastEvents as e (e._id ?? e.name)}
-					<div
-						class="transition-opacity duration-150"
-						class:hidden={!isVisible(e)}
-					>
+					<div class="transition-opacity duration-150" class:hidden={!isVisible(e)}>
 						<EventBlock
 							eventTitle={e.name}
 							date={formatEventDate(e.date)}
@@ -159,8 +161,8 @@
 	{#if !hasAnyVisible}
 		<div class="flex min-h-[40vh] items-center justify-center">
 			<div class="text-center">
-				<p class="text-sm font-semibold text-ecsess-400">No events in this category yet</p>
-				<p class="mt-1 text-xs text-ecsess-600">Check back soon for updates!</p>
+				<p class="text-ecsess-400 text-sm font-semibold">No events in this category yet</p>
+				<p class="text-ecsess-600 mt-1 text-xs">Check back soon for updates!</p>
 			</div>
 		</div>
 	{/if}

--- a/src/components/event/EventTabsContent.svelte
+++ b/src/components/event/EventTabsContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import EventBlock from 'components/event/EventBlock.svelte';
+	import EventDialog from 'components/event/EventDialog.svelte';
 	import { type EventPost, type EventCategory, EventLinkKind, type LinkType } from '$lib/schemas';
 
 	let { category, events } = $props<{
@@ -7,12 +8,20 @@
 		events: EventPost[];
 	}>();
 
-	const matchCategory = (e: EventPost): boolean => {
-		if (category === 'allEvents') return true;
-		const c: unknown = e.category ?? [];
-		return Array.isArray(c) ? c.includes(category) : (c as string) === category;
-	};
+	// ─── Dialog state ────────────────────────────────────────────────
+	let dialogOpen = $state(false);
+	let selectedEvent = $state<EventPost | null>(null);
 
+	function openDialog(event: EventPost) {
+		selectedEvent = event;
+		dialogOpen = true;
+	}
+
+	function closeDialog() {
+		dialogOpen = false;
+	}
+
+	// ─── Date helpers ────────────────────────────────────────────────
 	const parseEventDate = (dateString: string): Date => {
 		const parsed = new Date(dateString);
 		return isNaN(parsed.getTime()) ? new Date() : parsed;
@@ -21,48 +30,21 @@
 	const formatEventDate = (dateString: string): string => {
 		const date = parseEventDate(dateString);
 		const isMidnight = date.getUTCHours() === 0 && date.getUTCMinutes() === 0;
-
 		if (isMidnight) {
 			return date.toLocaleDateString('en-US', {
-				weekday: 'short',
-				year: 'numeric',
-				month: 'short',
-				day: 'numeric',
-				timeZone: 'UTC'
-			});
-		} else {
-			return date.toLocaleDateString('en-US', {
-				weekday: 'short',
-				year: 'numeric',
-				month: 'short',
-				day: 'numeric',
-				hour: 'numeric',
-				minute: '2-digit',
-				hour12: true
+				weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
 			});
 		}
+		return date.toLocaleDateString('en-US', {
+			weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
+			hour: 'numeric', minute: '2-digit', hour12: true
+		});
 	};
 
-	const isPastEvent = (dateString: string): boolean => {
+	const isPast = (dateString: string): boolean => {
 		const eventDate = parseEventDate(dateString);
-		const now = new Date();
-		const eventDatePlusOneDay = new Date(eventDate.getTime() + 24 * 60 * 60 * 1000);
-		return now > eventDatePlusOneDay;
+		return new Date() > new Date(eventDate.getTime() + 24 * 60 * 60 * 1000);
 	};
-
-	const filtered = $derived((events ?? []).filter(matchCategory));
-
-	const upcomingEvents = $derived(
-		filtered
-			.filter((e) => !isPastEvent(e.date))
-			.sort((a, b) => parseEventDate(a.date).getTime() - parseEventDate(b.date).getTime())
-	);
-
-	const finishedEvents = $derived(
-		filtered
-			.filter((e) => isPastEvent(e.date))
-			.sort((a, b) => parseEventDate(b.date).getTime() - parseEventDate(a.date).getTime())
-	);
 
 	const getLink = (e: EventPost, type: EventLinkKind): LinkType[] | null => {
 		let generalLinks: LinkType[] = [];
@@ -76,73 +58,128 @@
 		}
 		return generalLinks.length > 0 ? generalLinks : null;
 	};
+
+	// ─── CSS-class filtering: all events stay mounted, only visibility changes ──
+	// This avoids grid reflow and re-mount on every filter click.
+	const isVisible = (e: EventPost): boolean => {
+		if (category === 'allEvents') return true;
+		const c: unknown = e.category ?? [];
+		return Array.isArray(c) ? c.includes(category) : (c as string) === category;
+	};
+
+	// Sorted lists (all events, pre-sorted, never filtered out of DOM)
+	const allEvents = $derived(
+		[...(events ?? [])].sort((a, b) => {
+			const aIsPast = isPast(a.date);
+			const bIsPast = isPast(b.date);
+			if (aIsPast !== bIsPast) return aIsPast ? 1 : -1;
+			if (!aIsPast) return parseEventDate(a.date).getTime() - parseEventDate(b.date).getTime();
+			return parseEventDate(b.date).getTime() - parseEventDate(a.date).getTime();
+		})
+	);
+
+	const upcomingEvents = $derived(allEvents.filter((e) => !isPast(e.date)));
+	const pastEvents = $derived(allEvents.filter((e) => isPast(e.date)));
+
+	const hasVisibleUpcoming = $derived(upcomingEvents.some(isVisible));
+	const hasVisiblePast = $derived(pastEvents.some(isVisible));
+	const hasAnyVisible = $derived(hasVisibleUpcoming || hasVisiblePast);
 </script>
 
-<div class="w-full max-w-7xl py-8 text-left">
+<div class="w-full max-w-7xl py-8">
 
 	<!-- Upcoming Events -->
 	{#if upcomingEvents.length > 0}
-		<section class="mb-12">
-			<div class="mb-6 flex items-center gap-3">
+		<section
+			class="mb-10 transition-all duration-300"
+			class:hidden={!hasVisibleUpcoming}
+		>
+			<div class="mb-5 flex items-center gap-3">
 				<span class="h-px flex-1 bg-ecsess-800"></span>
-				<h2 class="text-[11px] font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
+				<h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
 				<span class="h-px flex-1 bg-ecsess-800"></span>
 			</div>
 
-			<div class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
+			<!-- Grid: all upcoming events rendered; hidden class toggled by CSS only -->
+			<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
 				{#each upcomingEvents as e (e._id ?? e.name)}
-					<EventBlock
-						eventTitle={e.name}
-						date={formatEventDate(e.date)}
-						location={e.location}
-						eventDescription={e.description}
-						thumbnail={e.thumbnail}
-						registrationLink={getLink(e, EventLinkKind.REGISTRATION)}
-						paymentLink={getLink(e, EventLinkKind.PAYMENT)}
-						generalLink={getLink(e, EventLinkKind.GENERAL)}
-						eventCategory={e.category}
-						isPastEvent={false}
-					/>
+					<div
+						class="transition-opacity duration-150"
+						class:hidden={!isVisible(e)}
+					>
+						<EventBlock
+							eventTitle={e.name}
+							date={formatEventDate(e.date)}
+							location={e.location}
+							thumbnail={e.thumbnail}
+							eventCategory={e.category}
+							isPastEvent={false}
+							onopen={() => openDialog(e)}
+						/>
+					</div>
 				{/each}
 			</div>
 		</section>
 	{/if}
 
 	<!-- Past Events -->
-	{#if finishedEvents.length > 0}
-		<section>
-			<div class="mb-6 flex items-center gap-3">
+	{#if pastEvents.length > 0}
+		<section
+			class="transition-all duration-300"
+			class:hidden={!hasVisiblePast}
+		>
+			<div class="mb-5 flex items-center gap-3">
 				<span class="h-px flex-1 bg-ecsess-800"></span>
-				<h2 class="text-[11px] font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
+				<h2 class="text-[10px] font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
 				<span class="h-px flex-1 bg-ecsess-800"></span>
 			</div>
 
-			<div class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
-				{#each finishedEvents as e (e._id ?? e.name)}
-					<EventBlock
-						eventTitle={e.name}
-						date={formatEventDate(e.date)}
-						location={e.location}
-						eventDescription={e.description}
-						thumbnail={e.thumbnail}
-						registrationLink={getLink(e, EventLinkKind.REGISTRATION)}
-						paymentLink={getLink(e, EventLinkKind.PAYMENT)}
-						generalLink={getLink(e, EventLinkKind.GENERAL)}
-						eventCategory={e.category}
-						isPastEvent={true}
-					/>
+			<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+				{#each pastEvents as e (e._id ?? e.name)}
+					<div
+						class="transition-opacity duration-150"
+						class:hidden={!isVisible(e)}
+					>
+						<EventBlock
+							eventTitle={e.name}
+							date={formatEventDate(e.date)}
+							location={e.location}
+							thumbnail={e.thumbnail}
+							eventCategory={e.category}
+							isPastEvent={true}
+							onopen={() => openDialog(e)}
+						/>
+					</div>
 				{/each}
 			</div>
 		</section>
 	{/if}
 
 	<!-- Empty state -->
-	{#if upcomingEvents.length === 0 && finishedEvents.length === 0}
+	{#if !hasAnyVisible}
 		<div class="flex min-h-[40vh] items-center justify-center">
 			<div class="text-center">
-				<p class="text-base font-semibold text-ecsess-400">No events in this category yet</p>
-				<p class="mt-1.5 text-sm text-ecsess-600">Check back soon for updates!</p>
+				<p class="text-sm font-semibold text-ecsess-400">No events in this category yet</p>
+				<p class="mt-1 text-xs text-ecsess-600">Check back soon for updates!</p>
 			</div>
 		</div>
 	{/if}
 </div>
+
+<!-- Single shared dialog — avoids mounting/unmounting per card -->
+{#if selectedEvent}
+	<EventDialog
+		open={dialogOpen}
+		eventTitle={selectedEvent.name}
+		date={formatEventDate(selectedEvent.date)}
+		location={selectedEvent.location}
+		eventDescription={selectedEvent.description}
+		thumbnail={selectedEvent.thumbnail}
+		registrationLink={getLink(selectedEvent, EventLinkKind.REGISTRATION)}
+		paymentLink={getLink(selectedEvent, EventLinkKind.PAYMENT)}
+		generalLink={getLink(selectedEvent, EventLinkKind.GENERAL)}
+		eventCategory={selectedEvent.category}
+		isPastEvent={isPast(selectedEvent.date)}
+		onclose={closeDialog}
+	/>
+{/if}

--- a/src/components/event/EventTabsContent.svelte
+++ b/src/components/event/EventTabsContent.svelte
@@ -14,19 +14,15 @@
 	};
 
 	const parseEventDate = (dateString: string): Date => {
-		// Try to parse various date formats
 		const parsed = new Date(dateString);
 		return isNaN(parsed.getTime()) ? new Date() : parsed;
 	};
 
 	const formatEventDate = (dateString: string): string => {
 		const date = parseEventDate(dateString);
-
-		// Check if the time is midnight (00:00) which likely means no time was specified
 		const isMidnight = date.getUTCHours() === 0 && date.getUTCMinutes() === 0;
 
 		if (isMidnight) {
-			// Format without time - just the date
 			return date.toLocaleDateString('en-US', {
 				weekday: 'long',
 				year: 'numeric',
@@ -35,7 +31,6 @@
 				timeZone: 'UTC'
 			});
 		} else {
-			// Format with time
 			return date.toLocaleDateString('en-US', {
 				weekday: 'long',
 				year: 'numeric',
@@ -50,43 +45,31 @@
 
 	const isPastEvent = (dateString: string): boolean => {
 		const eventDate = parseEventDate(dateString);
-		// Add 1 day to the event date
 		const now = new Date();
 		const eventDatePlusOneDay = new Date(eventDate.getTime() + 24 * 60 * 60 * 1000);
-
 		return now > eventDatePlusOneDay;
-		// return eventDate < now;
 	};
 
 	const filtered = $derived((events ?? []).filter(matchCategory));
 
 	const upcomingEvents = $derived(
 		filtered
-			.filter((e: { date: string }) => !isPastEvent(e.date))
-			.sort(
-				(a: { date: string }, b: { date: string }) =>
-					parseEventDate(a.date).getTime() - parseEventDate(b.date).getTime()
-			)
+			.filter((e) => !isPastEvent(e.date))
+			.sort((a, b) => parseEventDate(a.date).getTime() - parseEventDate(b.date).getTime())
 	);
 
 	const finishedEvents = $derived(
 		filtered
-			.filter((e: { date: string }) => isPastEvent(e.date))
-			.sort(
-				(a: { date: string }, b: { date: string }) =>
-					parseEventDate(b.date).getTime() - parseEventDate(a.date).getTime()
-			)
+			.filter((e) => isPastEvent(e.date))
+			.sort((a, b) => parseEventDate(b.date).getTime() - parseEventDate(a.date).getTime())
 	);
 
-	const getPaymentLink = (e: EventPost, type: EventLinkKind): LinkType[] | null => {
+	const getLink = (e: EventPost, type: EventLinkKind): LinkType[] | null => {
 		let generalLinks: LinkType[] = [];
 		for (const link of e.links ?? []) {
-			if (type == EventLinkKind.GENERAL && link.kind === EventLinkKind.GENERAL && link.url !== '') {
+			if (type === EventLinkKind.GENERAL && link.kind === EventLinkKind.GENERAL && link.url !== '') {
 				generalLinks.push(link);
-				// Limit general links to 4
-				if (generalLinks.length >= 4) {
-					break;
-				}
+				if (generalLinks.length >= 4) break;
 			} else if (link.kind === type && link.url !== '') {
 				return [link];
 			}
@@ -95,68 +78,70 @@
 	};
 </script>
 
-<div>
-	<div class="space-y-12 px-4 py-8 lg:px-8">
-		<!-- Upcoming Events -->
-		{#if upcomingEvents.length > 0}
-			<section>
-				<div class="mb-6 flex items-center gap-3">
-					<div class="bg-ecsess-200 h-1 w-16 rounded-full"></div>
-					<h2 class="text-ecsess-200 text-3xl font-bold">Upcoming Events</h2>
-				</div>
-				<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-					{#each upcomingEvents as e (e._id ?? e.name)}
-						<EventBlock
-							eventTitle={e.name}
-							date={formatEventDate(e.date)}
-							location={e.location}
-							eventDescription={e.description}
-							thumbnail={e.thumbnail}
-							registrationLink={getPaymentLink(e, EventLinkKind.REGISTRATION)}
-							paymentLink={getPaymentLink(e, EventLinkKind.PAYMENT)}
-							generalLink={getPaymentLink(e, EventLinkKind.GENERAL)}
-							eventCategory={e.category}
-							isPastEvent={false}
-						/>
-					{/each}
-				</div>
-			</section>
-		{/if}
-
-		<!-- Finished Events -->
-		{#if finishedEvents.length > 0}
-			<section>
-				<div class="mb-6 flex items-center gap-3">
-					<div class="bg-ecsess-400 h-1 w-16 rounded-full"></div>
-					<h2 class="text-ecsess-400 text-3xl font-bold">Past Events</h2>
-				</div>
-				<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-					{#each finishedEvents as e (e._id ?? e.name)}
-						<EventBlock
-							eventTitle={e.name}
-							date={formatEventDate(e.date)}
-							location={e.location}
-							eventDescription={e.description}
-							thumbnail={e.thumbnail}
-							registrationLink={getPaymentLink(e, EventLinkKind.REGISTRATION)}
-							paymentLink={getPaymentLink(e, EventLinkKind.PAYMENT)}
-							generalLink={getPaymentLink(e, EventLinkKind.GENERAL)}
-							eventCategory={e.category}
-							isPastEvent={true}
-						/>
-					{/each}
-				</div>
-			</section>
-		{/if}
-
-		<!-- No events message -->
-		{#if upcomingEvents.length === 0 && finishedEvents.length === 0}
-			<div class="flex min-h-[400px] items-center justify-center">
-				<div class="text-center">
-					<p class="text-xl font-semibold text-gray-600">No events in this category yet</p>
-					<p class="mt-2 text-gray-500">Check back soon for updates!</p>
-				</div>
+<div class="w-full max-w-3xl py-10 text-left">
+	<!-- Upcoming Events -->
+	{#if upcomingEvents.length > 0}
+		<section class="mb-12">
+			<div class="mb-8 flex items-center gap-4">
+				<span class="h-px flex-1 bg-ecsess-800/60"></span>
+				<h2 class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
+				<span class="h-px flex-1 bg-ecsess-800/60"></span>
 			</div>
-		{/if}
-	</div>
+
+			<div class="space-y-10">
+				{#each upcomingEvents as e (e._id ?? e.name)}
+					<EventBlock
+						eventTitle={e.name}
+						date={formatEventDate(e.date)}
+						location={e.location}
+						eventDescription={e.description}
+						thumbnail={e.thumbnail}
+						registrationLink={getLink(e, EventLinkKind.REGISTRATION)}
+						paymentLink={getLink(e, EventLinkKind.PAYMENT)}
+						generalLink={getLink(e, EventLinkKind.GENERAL)}
+						eventCategory={e.category}
+						isPastEvent={false}
+					/>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	<!-- Past Events -->
+	{#if finishedEvents.length > 0}
+		<section>
+			<div class="mb-8 flex items-center gap-4">
+				<span class="h-px flex-1 bg-ecsess-800/60"></span>
+				<h2 class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
+				<span class="h-px flex-1 bg-ecsess-800/60"></span>
+			</div>
+
+			<div class="space-y-10">
+				{#each finishedEvents as e (e._id ?? e.name)}
+					<EventBlock
+						eventTitle={e.name}
+						date={formatEventDate(e.date)}
+						location={e.location}
+						eventDescription={e.description}
+						thumbnail={e.thumbnail}
+						registrationLink={getLink(e, EventLinkKind.REGISTRATION)}
+						paymentLink={getLink(e, EventLinkKind.PAYMENT)}
+						generalLink={getLink(e, EventLinkKind.GENERAL)}
+						eventCategory={e.category}
+						isPastEvent={true}
+					/>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	<!-- Empty state -->
+	{#if upcomingEvents.length === 0 && finishedEvents.length === 0}
+		<div class="flex min-h-[40vh] items-center justify-center">
+			<div class="text-center">
+				<p class="text-lg font-semibold text-ecsess-400">No events in this category yet</p>
+				<p class="mt-2 text-sm text-ecsess-600">Check back soon for updates!</p>
+			</div>
+		</div>
+	{/if}
 </div>

--- a/src/components/event/EventTabsContent.svelte
+++ b/src/components/event/EventTabsContent.svelte
@@ -24,17 +24,17 @@
 
 		if (isMidnight) {
 			return date.toLocaleDateString('en-US', {
-				weekday: 'long',
+				weekday: 'short',
 				year: 'numeric',
-				month: 'long',
+				month: 'short',
 				day: 'numeric',
 				timeZone: 'UTC'
 			});
 		} else {
 			return date.toLocaleDateString('en-US', {
-				weekday: 'long',
+				weekday: 'short',
 				year: 'numeric',
-				month: 'long',
+				month: 'short',
 				day: 'numeric',
 				hour: 'numeric',
 				minute: '2-digit',
@@ -78,17 +78,18 @@
 	};
 </script>
 
-<div class="w-full max-w-3xl py-10 text-left">
+<div class="w-full max-w-7xl py-8 text-left">
+
 	<!-- Upcoming Events -->
 	{#if upcomingEvents.length > 0}
 		<section class="mb-12">
-			<div class="mb-8 flex items-center gap-4">
-				<span class="h-px flex-1 bg-ecsess-800/60"></span>
-				<h2 class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
-				<span class="h-px flex-1 bg-ecsess-800/60"></span>
+			<div class="mb-6 flex items-center gap-3">
+				<span class="h-px flex-1 bg-ecsess-800"></span>
+				<h2 class="text-[11px] font-bold uppercase tracking-[0.2em] text-ecsess-400">Upcoming</h2>
+				<span class="h-px flex-1 bg-ecsess-800"></span>
 			</div>
 
-			<div class="space-y-10">
+			<div class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
 				{#each upcomingEvents as e (e._id ?? e.name)}
 					<EventBlock
 						eventTitle={e.name}
@@ -110,13 +111,13 @@
 	<!-- Past Events -->
 	{#if finishedEvents.length > 0}
 		<section>
-			<div class="mb-8 flex items-center gap-4">
-				<span class="h-px flex-1 bg-ecsess-800/60"></span>
-				<h2 class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
-				<span class="h-px flex-1 bg-ecsess-800/60"></span>
+			<div class="mb-6 flex items-center gap-3">
+				<span class="h-px flex-1 bg-ecsess-800"></span>
+				<h2 class="text-[11px] font-bold uppercase tracking-[0.2em] text-ecsess-600">Past Events</h2>
+				<span class="h-px flex-1 bg-ecsess-800"></span>
 			</div>
 
-			<div class="space-y-10">
+			<div class="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
 				{#each finishedEvents as e (e._id ?? e.name)}
 					<EventBlock
 						eventTitle={e.name}
@@ -139,8 +140,8 @@
 	{#if upcomingEvents.length === 0 && finishedEvents.length === 0}
 		<div class="flex min-h-[40vh] items-center justify-center">
 			<div class="text-center">
-				<p class="text-lg font-semibold text-ecsess-400">No events in this category yet</p>
-				<p class="mt-2 text-sm text-ecsess-600">Check back soon for updates!</p>
+				<p class="text-base font-semibold text-ecsess-400">No events in this category yet</p>
+				<p class="mt-1.5 text-sm text-ecsess-600">Check back soon for updates!</p>
 			</div>
 		</div>
 	{/if}

--- a/src/components/event/EventTabsTrigger.svelte
+++ b/src/components/event/EventTabsTrigger.svelte
@@ -2,14 +2,14 @@
 	let { value, selected, onclick, children } = $props();
 </script>
 
-<div>
+<li>
 	<button
 		{value}
 		onclick={() => onclick(value)}
-		class="hover:border-b-ecsess-200 {selected
-			? 'border-b-ecsess-200'
-			: 'border-b-transparent'} border-b-4 px-2 pb-2 text-lg transition-all ease-in-out"
+		class="rounded-full px-4 py-1.5 text-sm font-semibold tracking-wide transition-colors {selected
+			? 'bg-ecsess-500 text-ecsess-50'
+			: 'border border-ecsess-700/60 text-ecsess-400 hover:border-ecsess-500 hover:text-ecsess-200'}"
 	>
 		{@render children()}
 	</button>
-</div>
+</li>

--- a/src/components/event/EventTabsTrigger.svelte
+++ b/src/components/event/EventTabsTrigger.svelte
@@ -8,7 +8,7 @@
 		onclick={() => onclick(value)}
 		class="rounded-full px-4 py-1.5 text-sm font-semibold tracking-wide transition-colors {selected
 			? 'bg-ecsess-500 text-ecsess-50'
-			: 'border border-ecsess-700/60 text-ecsess-400 hover:border-ecsess-500 hover:text-ecsess-200'}"
+			: 'border-ecsess-700/60 text-ecsess-400 hover:border-ecsess-500 hover:text-ecsess-200 border'}"
 	>
 		{@render children()}
 	</button>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -30,7 +30,7 @@
 
 <Section from="from-ecsess-black" to="to-ecsess-black" via="via-ecsess-600" direction="to-b" contentStart={true}>
 	<!-- Page header -->
-	<div class="w-full max-w-3xl pt-6 text-left">
+	<div class="w-full max-w-7xl pt-6 text-left">
 		<p class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-500 mb-2">ECSESS</p>
 		<h1 class="text-4xl font-bold text-ecsess-50 md:text-5xl lg:text-6xl text-balance py-0 mb-6">Events</h1>
 

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -10,13 +10,13 @@
 	let events = $derived(data.events ?? []);
 	let group = $state<EventCategory>(EventCategory.ALL_EVENTS);
 	let categories: { value: EventCategory; label: string }[] = [
-		{ value: EventCategory.ALL_EVENTS, label: 'All Events' },
+		{ value: EventCategory.ALL_EVENTS, label: 'All' },
 		{ value: EventCategory.ACADEMIC, label: 'Academic' },
 		{ value: EventCategory.PROFESSIONAL, label: 'Professional' },
 		{ value: EventCategory.SOCIAL, label: 'Social' },
 		{ value: EventCategory.TECHNICAL, label: 'Technical' }
 	];
-	// Handle tab change
+
 	function handleTabChange(selectedCategory: EventCategory) {
 		group = selectedCategory;
 	}
@@ -28,20 +28,26 @@
 	canonical={data.canonical}
 />
 
-<Section from="from-ecsess-black" to="to-ecsess-black" via="via-ecsess-600" direction="to-b">
-	<p class="page-title">Events</p>
+<Section from="from-ecsess-black" to="to-ecsess-black" via="via-ecsess-600" direction="to-b" contentStart={true}>
+	<!-- Page header -->
+	<div class="w-full max-w-3xl pt-6 text-left">
+		<p class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-500 mb-2">ECSESS</p>
+		<h1 class="text-4xl font-bold text-ecsess-50 md:text-5xl lg:text-6xl text-balance py-0 mb-6">Events</h1>
 
-	<div>
-		<ul class="flex flex-wrap justify-center gap-2">
+		<!-- Filter pills -->
+		<ul class="flex flex-wrap gap-2" role="tablist" aria-label="Filter events by category">
 			{#each categories as category}
 				<EventTabsTrigger
 					value={category.value}
 					selected={group === category.value}
-					onclick={handleTabChange}>{category.label}</EventTabsTrigger
+					onclick={handleTabChange}
 				>
+					{category.label}
+				</EventTabsTrigger>
 			{/each}
 		</ul>
-
-		<EventTabsContent category={group} {events} />
 	</div>
+
+	<!-- Feed -->
+	<EventTabsContent category={group} {events} />
 </Section>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -28,11 +28,19 @@
 	canonical={data.canonical}
 />
 
-<Section from="from-ecsess-black" to="to-ecsess-black" via="via-ecsess-600" direction="to-b" contentStart={true}>
+<Section
+	from="from-ecsess-black"
+	to="to-ecsess-black"
+	via="via-ecsess-600"
+	direction="to-b"
+	contentStart={true}
+>
 	<!-- Page header -->
 	<div class="w-full max-w-7xl pt-6 text-left">
-		<p class="text-xs font-bold uppercase tracking-[0.2em] text-ecsess-500 mb-2">ECSESS</p>
-		<h1 class="text-4xl font-bold text-ecsess-50 md:text-5xl lg:text-6xl text-balance py-0 mb-6">Events</h1>
+		<p class="text-ecsess-500 mb-2 text-xs font-bold tracking-[0.2em] uppercase">ECSESS</p>
+		<h1 class="text-ecsess-50 mb-6 py-0 text-4xl font-bold text-balance md:text-5xl lg:text-6xl">
+			Events
+		</h1>
 
 		<!-- Filter pills -->
 		<ul class="flex flex-wrap gap-2" role="tablist" aria-label="Filter events by category">


### PR DESCRIPTION
## Changes

### `EventBlock.svelte`
- Removed all action buttons and the expand/collapse toggle — the entire tile is now a clickable area that fires an `onopen` callback
- Added a hover overlay with an eye icon for clear affordance; no scale animation
- Text sizes reduced: `text-[11px]` title, `text-[10px]` meta, `h-2.5 w-2.5` icons
- Accepts an `onopen` prop instead of managing its own state

### `EventDialog.svelte` (new)
- Single shared dialog component with smooth CSS `opacity` + `translate-y` + `scale` entrance/exit transitions (no JS animation lib needed)
- Shows 16:7 landscape banner image, full title, date/location meta, rich-text description, and all action buttons (register, pay, add to calendar, general links)
- Closes on backdrop click, `Escape` key, or the X button

### `EventTabsContent.svelte`
- **CSS-class filtering**: all events remain mounted in the DOM; category filter toggles a `hidden` class per wrapper `<div>` instead of re-rendering the list — zero DOM mutations on filter change, instant and smooth with no layout reflow
- One `selectedEvent` state drives a single `<EventDialog>` instance (not one per card), keeping memory and mount cost minimal
- Added `xl:grid-cols-5` breakpoint for wider screens