### PR TITLE
Redesign resources page with category filtering

### DIFF
--- a/src/components/resource/ResourceCard.svelte
+++ b/src/components/resource/ResourceCard.svelte
@@ -1,6 +1,7 @@
-<script>
-	import { CircleArrowRight } from '@lucide/svelte';
+<script lang="ts">
+	import { ArrowUpRight } from '@lucide/svelte';
 	import Link from 'components/Link.svelte';
+
 	let {
 		title = '_Resource Title_',
 		description = 'Lorem ipsum',
@@ -8,25 +9,28 @@
 	} = $props();
 </script>
 
-<div
-	class="bg-ecsess-50 border-ecsess-100 relative h-fit max-w-xl min-w-12 rounded-md border px-4 py-2 transition-shadow hover:shadow-md md:py-0"
->
-	<div class="grid grid-cols-1 md:grid-cols-[7fr_1fr]">
-		<div class="flex flex-col items-start p-4">
-			<p class="text-ecsess-900 my-1 pb-1 text-left text-xl font-extrabold">
+<Link href={link} external={true} class="group block h-full">
+	<div
+		class="bg-ecsess-black border-ecsess-800 hover:border-ecsess-600 relative flex h-full flex-col justify-between gap-3 rounded-xl border p-5 transition-all duration-200 hover:shadow-lg"
+	>
+		<!-- Top row: title + arrow -->
+		<div class="flex items-start justify-between gap-3">
+			<h3 class="text-ecsess-50 group-hover:text-ecsess-200 py-0 text-lg font-bold leading-snug transition-colors text-balance">
 				{title}
-			</p>
-			<p class="text-ecsess-700 text-left text-base">
-				{description}
-			</p>
+			</h3>
+			<span
+				class="bg-ecsess-800 group-hover:bg-ecsess-600 mt-0.5 flex shrink-0 items-center justify-center rounded-full p-1.5 transition-colors duration-200"
+			>
+				<ArrowUpRight size="16" class="stroke-ecsess-300 group-hover:stroke-ecsess-50 transition-colors" />
+			</span>
 		</div>
-		<div class="m-4 place-self-center">
-			<Link href={link}>
-				<CircleArrowRight
-					size="42"
-					class="stroke-ecsess-700 hover:stroke-ecsess-500 cursor-pointer transition duration-200 active:scale-90"
-				/>
-			</Link>
-		</div>
+
+		<!-- Description -->
+		<p class="text-ecsess-400 text-sm leading-relaxed">
+			{description}
+		</p>
+
+		<!-- Bottom accent line -->
+		<div class="bg-ecsess-700 group-hover:bg-ecsess-500 mt-1 h-px w-full transition-colors duration-200"></div>
 	</div>
-</div>
+</Link>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -56,10 +56,21 @@ export type CouncilMember = {
 	linkedin?: string; // URL to profile, optional
 };
 
+export enum ResourceCategory {
+	ALL = 'all',
+	ACADEMIC = 'academic',
+	TECHNICAL = 'technical',
+	INVOLVEMENT = 'involvement',
+	SUSTAINABILITY = 'sustainability',
+	EQUITY = 'equity',
+	CAMPUS_LIFE = 'campusLife'
+}
+
 export type Resource = {
 	title: string;
 	url: string;
 	description: string;
+	category: ResourceCategory;
 };
 
 export type Sponsors = {

--- a/src/routes/resources/+page.server.ts
+++ b/src/routes/resources/+page.server.ts
@@ -1,11 +1,11 @@
 import type { Resource } from '$lib/schemas';
 import { getFromCMS } from '$lib/utils.js';
 
-// needs to concat and format this text
-const query = `*[_type == "resources"]{
+const query = `*[_type == "resources"] | order(category asc, title asc) {
   title,
   url,
   description,
+  category,
 }`;
 
 export const load = async ({ url }) => {

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -1,8 +1,42 @@
-<script>
+<script lang="ts">
+	import { ResourceCategory, type Resource } from '$lib/schemas';
 	import ResourceCard from 'components/resource/ResourceCard.svelte';
 	import Section from 'components/layout/Section.svelte';
 	import SeoMetaTags from 'components/layout/SeoMetaTags.svelte';
+	import EventTabsTrigger from 'components/event/EventTabsTrigger.svelte';
+
 	let { data } = $props();
+
+	let resources = $derived<Resource[]>(data.resources ?? []);
+	let activeCategory = $state<ResourceCategory | 'all'>('all');
+
+	type CategoryConfig = { value: ResourceCategory | 'all'; label: string; icon: string };
+
+	const categories: CategoryConfig[] = [
+		{ value: 'all', label: 'All', icon: '◈' },
+		{ value: ResourceCategory.ACADEMIC, label: 'Academic', icon: '📖' },
+		{ value: ResourceCategory.TECHNICAL, label: 'Technical', icon: '⚙' },
+		{ value: ResourceCategory.INVOLVEMENT, label: 'Involvement', icon: '🤝' },
+		{ value: ResourceCategory.SUSTAINABILITY, label: 'Sustainability', icon: '🌱' },
+		{ value: ResourceCategory.EQUITY, label: 'Equity', icon: '⚖' },
+		{ value: ResourceCategory.CAMPUS_LIFE, label: 'Campus Life', icon: '🎓' }
+	];
+
+	let filtered = $derived<Resource[]>(
+		activeCategory === 'all'
+			? resources
+			: resources.filter((r) => r.category === activeCategory)
+	);
+
+	function setCategory(cat: ResourceCategory | 'all') {
+		activeCategory = cat;
+	}
+
+	// Count per category for badge display
+	function countFor(cat: ResourceCategory | 'all'): number {
+		if (cat === 'all') return resources.length;
+		return resources.filter((r) => r.category === cat).length;
+	}
 </script>
 
 <SeoMetaTags
@@ -11,12 +45,66 @@
 	canonical={data.canonical}
 />
 
-<Section from="from-ecsess-black" to="to-ecsess-black" via="via-ecsess-800" direction="to-b">
-	<p class="page-title">Resources</p>
+<Section
+	from="from-ecsess-black"
+	to="to-ecsess-black"
+	via="via-ecsess-800"
+	direction="to-b"
+	contentStart={true}
+>
+	<!-- Page header -->
+	<div class="w-full max-w-7xl pt-6 text-left">
+		<p class="text-ecsess-500 mb-2 text-xs font-bold tracking-[0.2em] uppercase">ECSESS</p>
+		<h1 class="text-ecsess-50 mb-2 py-0 text-4xl font-bold text-balance md:text-5xl lg:text-6xl">
+			Resources
+		</h1>
+		<p class="text-ecsess-400 mb-8 max-w-xl text-base leading-relaxed">
+			Your hub for academic support, technical tools, campus involvement, and more.
+		</p>
 
-	<div class="grid gap-4">
-		{#each data.resources as re}
-			<ResourceCard title={re.title} link={re.url} description={re.description} />
-		{/each}
+		<!-- Category filter pills -->
+		<ul class="flex flex-wrap gap-2 mb-8" role="tablist" aria-label="Filter resources by category">
+			{#each categories as cat}
+				{#if countFor(cat.value) > 0 || cat.value === 'all'}
+					<EventTabsTrigger
+						value={cat.value}
+						selected={activeCategory === cat.value}
+						onclick={setCategory}
+					>
+						<span class="flex items-center gap-1.5">
+							{cat.label}
+							<span
+								class="rounded-full px-1.5 py-0.5 text-[10px] font-bold leading-none
+								{activeCategory === cat.value
+									? 'bg-ecsess-400/30 text-ecsess-50'
+									: 'bg-ecsess-800 text-ecsess-400'}"
+							>
+								{countFor(cat.value)}
+							</span>
+						</span>
+					</EventTabsTrigger>
+				{/if}
+			{/each}
+		</ul>
+	</div>
+
+	<!-- Resource grid -->
+	<div class="w-full max-w-7xl pb-16">
+		{#if filtered.length === 0}
+			<div class="border-ecsess-800 rounded-xl border border-dashed py-16 text-center">
+				<p class="text-ecsess-500 text-lg font-semibold">No resources in this category yet.</p>
+				<p class="text-ecsess-600 mt-1 text-sm">Check back soon or explore another category.</p>
+			</div>
+		{:else}
+			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{#each filtered as resource (resource.url + resource.title)}
+					<ResourceCard
+						title={resource.title}
+						link={resource.url}
+						description={resource.description}
+					/>
+				{/each}
+			</div>
+		{/if}
 	</div>
 </Section>


### PR DESCRIPTION
## Resources Page Redesign

Redesigns the `/resources` page with a category-based filtering system.

### Changes

**`src/lib/schemas.ts`**
- Added `ResourceCategory` enum with values: `all`, `academic`, `technical`, `involvement`, `sustainability`, `equity`, `campusLife`
- Added `category` field to the `Resource` type

**`src/routes/resources/+page.server.ts`**
- Updated GROQ query to fetch the `category` field from Sanity CMS
- Added `order(category asc, title asc)` sorting

**`src/components/resource/ResourceCard.svelte`**
- Redesigned as a full-height dark card with arrow icon, bottom accent line, and hover states
- Opens links in a new tab (`external={true}`)

**`src/routes/resources/+page.svelte`**
- New page header with subtitle matching the events page style
- Category filter pills using the existing `EventTabsTrigger` component with per-category count badges
- Responsive 1→2→3 column grid layout
- Empty state message when no resources match the selected category

### Notes
- Requires Sanity CMS resources to have a `category` field populated for filtering to work. Resources without a category will only appear under "All".